### PR TITLE
Fix stray character in utils module

### DIFF
--- a/papers2code_app2/utils.py
+++ b/papers2code_app2/utils.py
@@ -1,4 +1,3 @@
-\
 import logging
 from typing import Optional, Any, Dict, List
 from bson import ObjectId


### PR DESCRIPTION
## Summary
- remove unnecessary backslash at top of `papers2code_app2/utils.py`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_683fc428074c832fbfd7a01b3c40fc24