### PR TITLE
Reduce duplicate setup by centralizing deps

### DIFF
--- a/papers2code_app2/auth.py
+++ b/papers2code_app2/auth.py
@@ -9,6 +9,7 @@ import logging
 from .shared import config_settings
 from .database import get_users_collection_async  # Changed from get_users_collection_sync
 from .schemas_minimal import UserSchema
+from .constants import ACCESS_TOKEN_COOKIE_NAME
 
 logger = logging.getLogger(__name__)
 
@@ -18,7 +19,6 @@ ALGORITHM = config_settings.ALGORITHM
 ACCESS_TOKEN_EXPIRE_MINUTES = config_settings.ACCESS_TOKEN_EXPIRE_MINUTES
 REFRESH_TOKEN_EXPIRE_MINUTES = config_settings.REFRESH_TOKEN_EXPIRE_MINUTES
 
-ACCESS_TOKEN_COOKIE_NAME = "access_token_cookie"
 
 async def get_token_from_cookie(request: Request) -> Optional[str]:
     #logger.debug(f"get_token_from_cookie: Headers: {request.headers}")

--- a/papers2code_app2/constants.py
+++ b/papers2code_app2/constants.py
@@ -1,0 +1,6 @@
+ACCESS_TOKEN_COOKIE_NAME = "access_token_cookie"
+REFRESH_TOKEN_COOKIE_NAME = "refresh_token"
+OAUTH_STATE_COOKIE_NAME = "oauth_state_token"
+CSRF_TOKEN_COOKIE_NAME = "csrf_token_cookie"
+CSRF_TOKEN_HEADER_NAME = "X-CSRFToken"
+

--- a/papers2code_app2/dependencies.py
+++ b/papers2code_app2/dependencies.py
@@ -1,0 +1,26 @@
+from slowapi import Limiter
+from slowapi.util import get_remote_address
+
+from .services.paper_view_service import PaperViewService
+from .services.paper_action_service import PaperActionService
+from .services.paper_moderation_service import PaperModerationService
+from .services.implementation_progress_service import ImplementationProgressService
+
+limiter = Limiter(key_func=get_remote_address, default_limits=["200 per day", "50 per hour"])
+
+
+def get_paper_view_service() -> PaperViewService:
+    return PaperViewService()
+
+
+def get_paper_action_service() -> PaperActionService:
+    return PaperActionService()
+
+
+def get_paper_moderation_service() -> PaperModerationService:
+    return PaperModerationService()
+
+
+def get_implementation_progress_service() -> ImplementationProgressService:
+    return ImplementationProgressService()
+

--- a/papers2code_app2/main.py
+++ b/papers2code_app2/main.py
@@ -2,9 +2,10 @@ from fastapi import FastAPI, Request, HTTPException, APIRouter, status
 from fastapi.middleware.cors import CORSMiddleware # ADDED: For CORS
 from fastapi.responses import JSONResponse # For custom error handling
 from pydantic import BaseModel # ADDED: For type checking in AliasJSONResponse
-from slowapi import Limiter, _rate_limit_exceeded_handler
-from slowapi.util import get_remote_address
+from slowapi import _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
+from .dependencies import limiter
+from .constants import CSRF_TOKEN_COOKIE_NAME, CSRF_TOKEN_HEADER_NAME
 import uvicorn
 from fastapi.middleware.httpsredirect import HTTPSRedirectMiddleware # For HSTS
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint # ADDED
@@ -21,9 +22,6 @@ from .routers import auth_routes # Corrected import for auth_routes
 # Import the paper routers
 from .routers import paper_views_router, paper_actions_router, paper_moderation_router, implementation_progress_router
 
-# ADDED: CSRF constants (ensure these match auth_routes.py)
-CSRF_TOKEN_COOKIE_NAME = "csrf_token_cookie"
-CSRF_TOKEN_HEADER_NAME = "X-CSRFToken"
 
 # ADDED: CSRF Protection Middleware
 class CSRFProtectMiddleware(BaseHTTPMiddleware):
@@ -63,8 +61,6 @@ class AliasJSONResponse(JSONResponse):
             return super().render(content.model_dump(by_alias=True))
         return super().render(content)
 
-# Initialize Limiter
-limiter = Limiter(key_func=get_remote_address, default_limits=["200 per day", "50 per hour"]) 
 
 # --- Logging Configuration ---
 # MOVED from shared.py: BasicConfig should ideally be called once, e.g. in main.py

--- a/papers2code_app2/routers/auth_routes.py
+++ b/papers2code_app2/routers/auth_routes.py
@@ -6,6 +6,7 @@ from ..schemas_minimal import UserSchema, TokenResponse, UserMinimal, CsrfToken,
 from ..shared import config_settings
 from ..auth import get_current_user # SECRET_KEY, ALGORITHM, create_refresh_token are used by service
 from ..services.auth_service import AuthService
+from ..constants import OAUTH_STATE_COOKIE_NAME, CSRF_TOKEN_COOKIE_NAME
 from ..services.exceptions import (
     InvalidTokenException,
     UserNotFoundException,
@@ -21,11 +22,6 @@ router = APIRouter(
 )
 
 auth_service = AuthService()
-
-OAUTH_STATE_COOKIE_NAME = "oauth_state_token" # Used for setting and clearing
-ACCESS_TOKEN_COOKIE_NAME = "access_token_cookie" # Used for clearing on error/logout
-REFRESH_TOKEN_COOKIE_NAME = "refresh_token" # Used for clearing on error/logout
-CSRF_TOKEN_COOKIE_NAME = "csrf_token_cookie" # Used for /csrf-token endpoint
 
 @router.get("/csrf-token", response_model=CsrfToken)
 async def get_csrf_token(request: Request, response: Response):

--- a/papers2code_app2/routers/implementation_progress_router.py
+++ b/papers2code_app2/routers/implementation_progress_router.py
@@ -11,6 +11,7 @@ from ..schemas_implementation_progress import (
     ProgressStatus 
 )
 from ..services.implementation_progress_service import ImplementationProgressService
+from ..dependencies import get_implementation_progress_service
 from ..services.exceptions import NotFoundException, UserNotContributorException, InvalidRequestException
 from ..auth import get_current_user 
 from ..schemas_minimal import UserSchema as UserInDBMinimalSchema
@@ -22,9 +23,6 @@ router = APIRouter(
     tags=["Implementation Progress"], 
 )
 
-# Dependency to get the service
-def get_implementation_progress_service() -> ImplementationProgressService:
-    return ImplementationProgressService()
 
 @router.post("/paper/{paper_id}/join", response_model=ImplementationProgress, status_code=status.HTTP_200_OK) 
 async def join_or_create_implementation_progress(

--- a/papers2code_app2/routers/paper_views_router.py
+++ b/papers2code_app2/routers/paper_views_router.py
@@ -5,6 +5,7 @@ import asyncio # Add asyncio import
 from ..schemas_papers import PaperResponse, PaginatedPaperResponse 
 from ..schemas_minimal import UserSchema as User # Using UserSchema as User for type hinting
 from ..services.paper_view_service import PaperViewService
+from ..dependencies import get_paper_view_service
 from ..services.exceptions import PaperNotFoundException, DatabaseOperationException, ServiceException
 from ..auth import get_current_user_optional # Changed from get_current_user
 from ..utils import transform_paper_async
@@ -18,9 +19,6 @@ router = APIRouter(
     tags=["papers-view"],
 )
 
-# Dependency for PaperViewService
-def get_paper_view_service() -> PaperViewService:
-    return PaperViewService()
 
 @router.get("/", response_model=PaginatedPaperResponse)
 async def list_papers(

--- a/papers2code_app2/services/auth_service.py
+++ b/papers2code_app2/services/auth_service.py
@@ -19,13 +19,15 @@ import secrets # Add import for secrets
 from datetime import datetime, timedelta, timezone # Add datetime, timedelta, timezone imports
 from pymongo import ReturnDocument # Add pymongo import
 import logging # Add logging import
+from ..constants import (
+    ACCESS_TOKEN_COOKIE_NAME,
+    REFRESH_TOKEN_COOKIE_NAME,
+    OAUTH_STATE_COOKIE_NAME,
+    CSRF_TOKEN_COOKIE_NAME,
+)
 
 logger = logging.getLogger(__name__)
 
-ACCESS_TOKEN_COOKIE_NAME = "access_token_cookie"
-REFRESH_TOKEN_COOKIE_NAME = "refresh_token"
-OAUTH_STATE_COOKIE_NAME = "oauth_state_token" # Define OAUTH_STATE_COOKIE_NAME
-CSRF_TOKEN_COOKIE_NAME = "csrf_token_cookie" # Define CSRF_TOKEN_COOKIE_NAME
 
 class AuthService:
     def generate_csrf_token(self) -> str:


### PR DESCRIPTION
## Summary
- centralize cookie names in `constants.py`
- create `dependencies.py` with shared service factories and Limiter
- refactor routers to import factories and limiter
- use shared constants and limiter in `main.py`
- update auth modules to use new constants

## Testing
- `ruff check papers2code_app2/routers/paper_moderation_router.py`
- `ruff check papers2code_app2/routers/paper_actions_router.py`


------
https://chatgpt.com/codex/tasks/task_e_6844f63c1458832fb7e95f3e0ace93a4