### PR TITLE
Add service error handling decorator

### DIFF
--- a/papers2code_app2/error_handlers.py
+++ b/papers2code_app2/error_handlers.py
@@ -1,0 +1,51 @@
+import logging
+from functools import wraps
+from fastapi import HTTPException, status
+
+from .services.exceptions import (
+    PaperNotFoundException,
+    AlreadyVotedException,
+    VoteProcessingException,
+    InvalidActionException,
+    UserActionException,
+    ServiceException,
+    DatabaseOperationException,
+    NotFoundException,
+    UserNotContributorException,
+    InvalidRequestException,
+)
+
+logger = logging.getLogger(__name__)
+
+# Mapping of service exceptions to HTTP status codes
+EXCEPTION_STATUS_MAP = {
+    PaperNotFoundException: status.HTTP_404_NOT_FOUND,
+    NotFoundException: status.HTTP_404_NOT_FOUND,
+    AlreadyVotedException: status.HTTP_409_CONFLICT,
+    InvalidActionException: status.HTTP_400_BAD_REQUEST,
+    InvalidRequestException: status.HTTP_400_BAD_REQUEST,
+    UserActionException: status.HTTP_400_BAD_REQUEST,
+    UserNotContributorException: status.HTTP_403_FORBIDDEN,
+    VoteProcessingException: status.HTTP_500_INTERNAL_SERVER_ERROR,
+    DatabaseOperationException: status.HTTP_500_INTERNAL_SERVER_ERROR,
+    ServiceException: status.HTTP_500_INTERNAL_SERVER_ERROR,
+}
+
+
+def handle_service_errors(func):
+    """Decorator to translate service layer exceptions into HTTPException."""
+
+    @wraps(func)
+    async def wrapper(*args, **kwargs):
+        try:
+            return await func(*args, **kwargs)
+        except HTTPException:
+            raise
+        except Exception as exc:  # pylint: disable=broad-except
+            for exc_cls, status_code in EXCEPTION_STATUS_MAP.items():
+                if isinstance(exc, exc_cls):
+                    logger.debug("Service exception %s mapped to status %s", exc_cls.__name__, status_code)
+                    raise HTTPException(status_code=status_code, detail=str(exc)) from exc
+            raise
+
+    return wrapper

--- a/papers2code_app2/routers/implementation_progress_router.py
+++ b/papers2code_app2/routers/implementation_progress_router.py
@@ -12,6 +12,7 @@ from ..schemas_implementation_progress import (
 )
 from ..services.implementation_progress_service import ImplementationProgressService
 from ..dependencies import get_implementation_progress_service
+from ..error_handlers import handle_service_errors
 from ..services.exceptions import NotFoundException, UserNotContributorException, InvalidRequestException
 from ..auth import get_current_user 
 from ..schemas_minimal import UserSchema as UserInDBMinimalSchema
@@ -24,7 +25,8 @@ router = APIRouter(
 )
 
 
-@router.post("/paper/{paper_id}/join", response_model=ImplementationProgress, status_code=status.HTTP_200_OK) 
+@router.post("/paper/{paper_id}/join", response_model=ImplementationProgress, status_code=status.HTTP_200_OK)
+@handle_service_errors
 async def join_or_create_implementation_progress(
     paper_id: str,
     current_user: UserInDBMinimalSchema = Depends(get_current_user),
@@ -33,57 +35,44 @@ async def join_or_create_implementation_progress(
     try:
         progress = await service.join_or_create_progress(paper_id, str(current_user.id))
         return progress
-    except NotFoundException as e:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
-    except InvalidRequestException as e:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
     except Exception as e:
         logger.error(f"Error in join_or_create_implementation_progress: {e}", exc_info=True)
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="An unexpected error occurred.")
 
-@router.get("/paper/{paper_id}", response_model=Optional[ImplementationProgress]) 
+@router.get("/paper/{paper_id}", response_model=Optional[ImplementationProgress])
+@handle_service_errors
 async def get_implementation_progress_for_paper(
     paper_id: str,
     service: ImplementationProgressService = Depends(get_implementation_progress_service)
 ):
     try:
         progress = await service.get_progress_by_paper_id(paper_id)
-        # Return 404 if progress is None, which is a valid response for Optional[ImplementationProgress]
-        # The client will receive null if not found, which is fine. Or we can explicitly raise 404.
-        # For consistency with other GET by ID, let's raise 404 if not found.
         if not progress:
-            # This was commented out, but it's good practice to return 404 if the specific resource (progress for this paper) isn't found.
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"No implementation progress found for paper ID {paper_id}")
         return progress
-    except InvalidRequestException as e: 
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
     except Exception as e:
         logger.error(f"Error in get_implementation_progress_for_paper: {e}", exc_info=True)
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="An unexpected error occurred.")
 
-@router.get("/{progress_id}", response_model=ImplementationProgress) 
-async def get_implementation_progress_by_id_route( 
+@router.get("/{progress_id}", response_model=ImplementationProgress)
+@handle_service_errors
+async def get_implementation_progress_by_id_route(
     progress_id: str,
     service: ImplementationProgressService = Depends(get_implementation_progress_service)
 ):
     try:
         progress = await service.get_progress_by_id(progress_id)
         if not progress:
-            # This was previously raising NotFoundException from the service, which is good.
-            # Here, we ensure it translates to HTTP 404.
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Implementation progress with ID {progress_id} not found.")
         return progress
-    # Removed redundant NotFoundException catch, as the service raises it and it would be caught by the generic Exception handler or a specific one if needed.
-    except InvalidRequestException as e: 
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
     except Exception as e:
         logger.error(f"Error in get_implementation_progress_by_id_route: {e}", exc_info=True)
-        # If the service raised NotFoundException, it will be caught here if not handled before.
         if isinstance(e, NotFoundException):
-             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="An unexpected error occurred.")
 
-@router.post("/{progress_id}/sections/{section_id}/components", response_model=ImplementationProgress, status_code=status.HTTP_201_CREATED) 
+@router.post("/{progress_id}/sections/{section_id}/components", response_model=ImplementationProgress, status_code=status.HTTP_201_CREATED)
+@handle_service_errors
 async def add_component_to_progress_section(
     progress_id: str,
     section_id: str, 
@@ -94,17 +83,12 @@ async def add_component_to_progress_section(
     try:
         progress = await service.add_component_to_progress(progress_id, str(current_user.id), component_data, section_id)
         return progress
-    except NotFoundException as e:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
-    except UserNotContributorException as e:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(e))
-    except InvalidRequestException as e: 
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
     except Exception as e:
         logger.error(f"Error in add_component_to_progress_section: {e}", exc_info=True)
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="An unexpected error occurred.")
 
-@router.put("/{progress_id}/sections/{section_id}/components/{component_id}", response_model=ImplementationProgress) 
+@router.put("/{progress_id}/sections/{section_id}/components/{component_id}", response_model=ImplementationProgress)
+@handle_service_errors
 async def update_component_in_progress_section(
     progress_id: str,
     section_id: str, 
@@ -116,17 +100,12 @@ async def update_component_in_progress_section(
     try:
         progress = await service.update_component_in_progress(progress_id, section_id, component_id, str(current_user.id), component_data)
         return progress
-    except NotFoundException as e:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
-    except UserNotContributorException as e:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(e))
-    except InvalidRequestException as e: 
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
     except Exception as e:
         logger.error(f"Error in update_component_in_progress_section: {e}", exc_info=True)
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="An unexpected error occurred.")
 
-@router.delete("/{progress_id}/sections/{section_id}/components/{component_id}", response_model=ImplementationProgress) 
+@router.delete("/{progress_id}/sections/{section_id}/components/{component_id}", response_model=ImplementationProgress)
+@handle_service_errors
 async def remove_component_from_progress_section(
     progress_id: str,
     section_id: str, 
@@ -137,12 +116,6 @@ async def remove_component_from_progress_section(
     try:
         progress = await service.remove_component_from_progress(progress_id, section_id, component_id, str(current_user.id))
         return progress
-    except NotFoundException as e:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
-    except UserNotContributorException as e:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(e))
-    except InvalidRequestException as e:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
     except Exception as e:
         logger.error(f"Error in remove_component_from_progress_section: {e}", exc_info=True)
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="An unexpected error occurred.")
@@ -150,7 +123,8 @@ async def remove_component_from_progress_section(
 class ProgressStatusUpdatePayload(BaseModel):
     new_status: ProgressStatus
 
-@router.put("/{progress_id}/status", response_model=ImplementationProgress) 
+@router.put("/{progress_id}/status", response_model=ImplementationProgress)
+@handle_service_errors
 async def update_progress_status_endpoint(
     progress_id: str,
     payload: ProgressStatusUpdatePayload,
@@ -160,13 +134,7 @@ async def update_progress_status_endpoint(
     try:
         progress = await service.update_progress_status(progress_id, str(current_user.id), payload.new_status)
         return progress
-    except NotFoundException as e:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
-    except UserNotContributorException as e:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(e))
-    except InvalidRequestException as e: 
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
-    except ValueError as e: 
+    except ValueError as e:
         raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e))
     except Exception as e:
         logger.error(f"Error in update_progress_status_endpoint: {e}", exc_info=True)


### PR DESCRIPTION
## Summary
- add `handle_service_errors` decorator to centralize mapping service exceptions to HTTP error codes
- apply decorator to paper action, moderation, view, and implementation progress routers

## Testing
- `python -m py_compile papers2code_app2/routers/paper_actions_router.py papers2code_app2/routers/paper_moderation_router.py papers2code_app2/routers/implementation_progress_router.py papers2code_app2/routers/paper_views_router.py`
- `python -m py_compile papers2code_app2/error_handlers.py`


------
https://chatgpt.com/codex/tasks/task_e_684500c817f0832f8983561b3673c80d